### PR TITLE
fix: Routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,8 @@ const App = (): JSX.Element => {
     <BrowserRouter>
       <main className="flex justify-center items-center bg-blue-400 h-[100vh] w-full">
         <Routes>
-          {forecast ? (
-            <Route path="/forecast" element={<Forecast data={forecast} />} />
-          ) : (
-            <Route
+          <Route path="/forecast" element={<Forecast data={forecast} />} />
+          <Route
               path="/"
               element={
                 <Search
@@ -26,7 +24,6 @@ const App = (): JSX.Element => {
                 />
               }
             />
-          )}
         </Routes>
       </main>
     </BrowserRouter>

--- a/src/components/Forecast.tsx
+++ b/src/components/Forecast.tsx
@@ -12,7 +12,7 @@ import IconWrapper from "./IconWrapper";
 import { Link } from "react-router-dom";
 
 type Props = {
-  data: forecastType;
+  data: forecastType | null;
 };
 
 const Degree = ({ temp }: { temp: number }): JSX.Element => (
@@ -23,6 +23,10 @@ const Degree = ({ temp }: { temp: number }): JSX.Element => (
 );
 
 const Forecast = ({ data }: Props): JSX.Element => {
+  if (!data) {
+    return <div>No Data</div>
+  }
+
   const today = data.list[0];
   //const navigate = useNavigate();
 


### PR DESCRIPTION
## Description

Fix the definition of routes in the app component.

## Notes

Note that this is a rather "hacky" solution because it will re-render the Forecast page multiple times until it received the data from the API.

## Suggestion

I would recommend the following:

Define two routes:
1. `/`: The home page/search page
2. `/forecast`

On search submit, redirect to `/forecast?lat=LAT&lng=LNG` where you pass the `lat` and `lng` provided by the city of the search result.
The `/forecast` page then gets the query parameters from the URL and fetches the weather details for this location.
This way, you do not have to pass data around between multiple routes, instead, you are using the URL as _state machine_.
Alternatively, you could use [`React.Context`](https://reactjs.org/docs/context.html) to store the search result in a global context, which you can access from any page. Passing data around should be avoided where possible, in order to separate the pages by concern
